### PR TITLE
より軽量なAPIを使用し,ID取得時の通信量を削減する

### DIFF
--- a/httpreq/__init__.py
+++ b/httpreq/__init__.py
@@ -1,12 +1,23 @@
+import brotli
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 
 HEADERS = {
-    'user-agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) '
-    'AppleWebKit/537.36 (KHTML, like Gecko) '
-    'Chrome/69.0.3497.100 Safari/537.36'}
+    'user-agent':'Mozilla/5.0 (Windows NT 6.1; Win64; x64) '
+                 'AppleWebKit/537.36 (KHTML, like Gecko) '
+                 'Chrome/69.0.3497.100 Safari/537.36'}
+
+HEADERS_M = {
+    'user-agent':'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) '
+                 'AppleWebKit/605.1.15 (KHTML, like Gecko) '
+                 'CriOS/69.0.3497.91 Mobile/15E148 Safari/605.1',
+    'accept': '*/*',
+    'accept-language': 'en-US,en;q=0.5',
+    'accept-encoding' : 'gzip, br',
+    'x-youTube-client-Name': '2',
+    'x-youTube-client-version': '2.20200410'}
 
 class HttpRequest:
 
@@ -20,6 +31,9 @@ class HttpRequest:
     def get_session(self):
         return self.session
 
-    def get(self, url):
+    def get(self, url, params=None):
             return self.session.get(
-                url=url, headers=HEADERS, timeout=(20,10), stream=True)
+                url=url, params=params, headers=HEADERS_M, 
+                timeout=(20,10), stream=True)
+            
+

--- a/httpreq/__init__.py
+++ b/httpreq/__init__.py
@@ -4,11 +4,6 @@ from urllib3.util import Retry
 
 
 HEADERS = {
-    'user-agent':'Mozilla/5.0 (Windows NT 6.1; Win64; x64) '
-                 'AppleWebKit/537.36 (KHTML, like Gecko) '
-                 'Chrome/69.0.3497.100 Safari/537.36'}
-
-HEADERS_M = {
     'user-agent':'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) '
                  'AppleWebKit/605.1.15 (KHTML, like Gecko) '
                  'CriOS/69.0.3497.91 Mobile/15E148 Safari/605.1',
@@ -32,7 +27,5 @@ class HttpRequest:
 
     def get(self, url, params=None):
         return self.session.get(
-            url=url, params=params, headers=HEADERS_M, 
+            url=url, params=params, headers=HEADERS, 
             timeout=(20,10), stream=True)
-            
-

--- a/httpreq/__init__.py
+++ b/httpreq/__init__.py
@@ -1,7 +1,4 @@
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
-
 
 HEADERS = {
     'user-agent':'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) '
@@ -10,22 +7,44 @@ HEADERS = {
     'accept': '*/*',
     'accept-language': 'en-US,en;q=0.5',
     'accept-encoding' : 'gzip, br',
-    'x-youTube-client-name': '2',
-    'x-youTube-client-version': '2.20200410'}
+    'x-youtube-client-name': '2',
+    'x-youtube-client-version': '2.20200410'}
+
+# エラー発生時に返す空のレスポンス。
+# 返した先でもtext属性が使えるようにするため。
+# text:'', status_code:None
+EMPTY_RESPONSE = requests.Response()
 
 class HttpRequest:
 
     def __init__(self):
+        self._init_session()
+
+    def _init_session(self):
         self.session = requests.Session()
-        self.retries = Retry(total=5, # リトライ回数
-            backoff_factor=3, # リトライが複数回起こったときに伸ばす間隔
-            status_forcelist=[400, 403, 429, 500]) # タイムアウト以外の捕捉対象status_code
-        self.session.mount("https://", HTTPAdapter(max_retries=self.retries))
 
     def get_session(self):
         return self.session
 
     def get(self, url, params=None):
-        return self.session.get(
-            url=url, params=params, headers=HEADERS, 
-            timeout=(20,10), stream=True)
+        try:
+            response = self.session.get(
+                url=url, params=params, headers=HEADERS, 
+                timeout=(10,10), stream=True)
+            response.raise_for_status()
+            return response
+        except requests.exceptions.ConnectionError:
+            # 接続切断によるsocket.gaierror等
+            print('ネットワークに問題が発生しました。')
+        except requests.exceptions.ConnectTimeout:
+            # リトライが規定回数を超えた場合
+            print('接続がタイムアウトしました。')
+        except requests.exceptions.HTTPError:
+            print('不正なHTTPレスポンスを検出しました。')
+        except requests.exceptions.RequestException as e:
+            # その他のエラー
+            print(f'Error:RequestException{type(e)} {str(e)}')
+        # エラー発生時はセッションを初期化する。            
+        self._init_session()
+        # 空のレスポンスを返す。
+        return EMPTY_RESPONSE

--- a/httpreq/__init__.py
+++ b/httpreq/__init__.py
@@ -1,0 +1,25 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+
+HEADERS = {
+    'user-agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/69.0.3497.100 Safari/537.36'}
+
+class HttpRequest:
+
+    def __init__(self):
+        self.session = requests.Session()
+        self.retries = Retry(total=5, # リトライ回数
+            backoff_factor=3, # リトライが複数回起こったときに伸ばす間隔
+            status_forcelist=[400, 403, 429, 500]) # タイムアウト以外の捕捉対象status_code
+        self.session.mount("https://", HTTPAdapter(max_retries=self.retries))
+
+    def get_session(self):
+        return self.session
+
+    def get(self, url):
+            return self.session.get(
+                url=url, headers=HEADERS, timeout=(20,10), stream=True)

--- a/httpreq/__init__.py
+++ b/httpreq/__init__.py
@@ -1,4 +1,3 @@
-import brotli
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -16,7 +15,7 @@ HEADERS_M = {
     'accept': '*/*',
     'accept-language': 'en-US,en;q=0.5',
     'accept-encoding' : 'gzip, br',
-    'x-youTube-client-Name': '2',
+    'x-youTube-client-name': '2',
     'x-youTube-client-version': '2.20200410'}
 
 class HttpRequest:
@@ -32,8 +31,8 @@ class HttpRequest:
         return self.session
 
     def get(self, url, params=None):
-            return self.session.get(
-                url=url, params=params, headers=HEADERS_M, 
-                timeout=(20,10), stream=True)
+        return self.session.get(
+            url=url, params=params, headers=HEADERS_M, 
+            timeout=(20,10), stream=True)
             
 

--- a/mikochiku_alarm.py
+++ b/mikochiku_alarm.py
@@ -24,9 +24,6 @@ else:
     from Queue import Queue
     from urllib import urlencode
 
-PATTERN_DATA = re.compile(r'window\["ytInitialData"\] = (.*?);')
-
-PATTERN_LIVE_VIDEO  = re.compile(r'LIVE_NOW.*?"videoId":"([^"]+)"')
 
 class MikochikuAlarm(QWidget):
 

--- a/mikochiku_alarm.py
+++ b/mikochiku_alarm.py
@@ -4,16 +4,12 @@ import sys
 import os
 import time
 import webbrowser
-import requests
 import pygame.mixer
 import json
 import settings
 import config_tab
 import re
 import vparser
-from urllib3.util import Retry
-from urllib3.exceptions import MaxRetryError
-from requests.adapters import HTTPAdapter
 from PyQt5.QtWidgets import QWidget, QCheckBox, QPushButton, QApplication, QLabel, QListWidget, QMessageBox
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt, QTimer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.9.0
+brotli==1.0.7
 certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-brotli==1.0.7
 certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9

--- a/vparser/__init__.py
+++ b/vparser/__init__.py
@@ -1,0 +1,200 @@
+'''
+module : vparser
+
+APIから得たJSONから、ライブ動画IDを取り出す。
+'''
+
+import json
+import requests
+from httpreq import HttpRequest
+
+'''
+JSONパース用のpath
+'''
+p_tabroot = [
+    'response',
+    'contents',
+    'singleColumnBrowseResultsRenderer',
+    'tabs'
+]
+
+sx_tabtitle = [
+    'tabRenderer',
+    'title'
+]
+
+sx_contents_part = [
+    'tabRenderer',
+    'content',
+    'sectionListRenderer',
+    'contents',
+    0,
+    'itemSectionRenderer',
+    'contents'
+]
+
+p_videotab = [
+    'response',
+    'contents',
+    'singleColumnBrowseResultsRenderer',
+    'tabs',
+    1,
+    'tabRenderer',
+    'title'
+]
+
+p_contents = [
+    'response',
+    'contents',
+    'singleColumnBrowseResultsRenderer',
+    'tabs',
+    1,
+    'tabRenderer',
+    'content',
+    'sectionListRenderer',
+    'contents',
+    0,
+    'itemSectionRenderer',
+    'contents'
+]
+
+px_vid = [
+    'compactVideoRenderer',
+    'videoId',
+]
+
+px_title = [
+    'compactVideoRenderer',
+    'title',
+    'runs',
+    0,
+    'text'
+]
+
+px_status = [
+    'compactVideoRenderer',
+    'thumbnailOverlays',
+    0,
+    'thumbnailOverlayTimeStatusRenderer',
+    'style'
+]
+
+'''
+404エラーのJSON path
+'''
+x_404_error = [
+    'response',
+    'responseContext',
+    'errors',
+    0
+]
+
+
+class InvalidChannelIDException(requests.exceptions.RequestException):
+    '''
+    指定したチャンネルIDのページが不存在（404）の場合に投げる例外
+    '''
+    pass
+
+
+def get_source_json(req:HttpRequest, channel_id):
+    '''
+    Query APIを叩いてライブ動画IDのリストを含むJSONデータを取り出す.
+
+    戻り値:(str):動画IDのリストを含むJSON文字列。
+        リクエスト時にネットワークエラー等のエラー発生した場合は
+        エラーを表すJSONを返す。現時点ではダミーで{"error":1}
+
+        TODO: エラー種類に応じて値を切り替えて処理できるようにする。
+        またはエラー内容ごとに異なる例外を伝播させる。
+    '''
+    try:
+        url = f'https://m.youtube.com/channel/{channel_id}/videos'
+        params = {'view':2, 'flow':'list', 'pbj':1}
+        response = req.get(url=url, params=params)
+        response.raise_for_status()
+        return response.text
+    except requests.exceptions.ConnectTimeout as e:
+        print('タイムアウトしました。')
+        # sessionを取得しなおす。
+        self.request = HttpRequest()
+    except requests.exceptions.RequestException as e:
+        # NOTE: Query APIでは誤ったChannelIDを指定してもRequestExceptionは発生しない。
+        if response.status_code == 404:
+            # GUI側に404エラーを伝播させる
+            raise InvalidChannelIDException()
+        print(f'Error:{response.status_code}')
+    except Exception as e:
+        print(type(e),str(e))
+    # 例外が起きてもエラーjsonを返して継続する。
+    return json.dumps({'error':1})
+
+
+def extract_video_ids(source_json:str):
+    '''
+    JSONからライブ動画のIDのリストを抽出する。
+    
+    戻り値:(list):ライブ動画のIDのリスト。
+        ライブ動画なし,またはJSONが不正なフォーマット/JSON取得時にエラー発生の場合
+        空のリスト([])を返す。
+    '''
+    try:
+        source_dic = json.loads(source_json)
+    except json.JSONDecodeError as e:
+        print(type(e).str(e))
+        return []
+    # チャンネルページが存在しない場合、APIはエラーJSONを吐くので例外発生させる。
+    if _getitem(source_dic, x_404_error) == (
+        'This channel does not exist.'
+    ):
+        raise InvalidChannelIDException()
+    
+    if source_dic.get('error'):
+        return []
+
+    return _get_live_vids(source_dic)
+
+def _get_live_vids(dic):
+    tab = _getitem(dic, p_videotab)
+    contents = _getitem(dic, p_contents)
+    
+    if contents is None:
+        # Videosタブが通常位置と異なるため探し直す
+        contents = _find_videos_tab(dic)
+    if contents is None:
+        # Videosタブが見つからなかった
+        return []     
+
+    return [ _getitem(c, px_vid) for c in contents
+        if _getitem(c, px_status) == 'LIVE' ]       
+
+
+def _find_videos_tab(dic):
+    """
+    Videosタブを探す
+    """
+    tabroot = _getitem(dic, p_tabroot)
+    if tabroot is None:
+        return 
+    for tab in tabroot:
+        tabtitle = _getitem(tab, sx_tabtitle)
+        if tabtitle is None:
+            continue
+        if tabtitle == 'Videos':
+            return _getitem(tab, sx_contents_part)
+
+
+def _getitem(dict_body, items: list):
+    for item in items:
+        if dict_body is None:
+            break
+        if isinstance(dict_body, dict):
+            dict_body = dict_body.get(item)
+            continue
+        if isinstance(item, int) and \
+            isinstance(dict_body, list) and \
+            len(dict_body) > item:
+            dict_body = dict_body[item]
+            continue
+        return None
+    return dict_body


### PR DESCRIPTION
## 関連issue
#27

これまでは配信ページを直接スクレイピングしていたので、通信量が数１０キロバイトと大きかったのですが、
YunzheZJUさんが #27で教えてくださった APIを使用することにより、1回あたりの通信量が数キロバイトまで削減できます。
 