### PR TITLE
動作に必要なパッケージ（brotli & pygame）を requirements.txt に追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+brotli==1.0.7
 certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
+pygame==1.9.6
 PyQt5==5.14.2
 PyQt5-sip==12.7.2
 python-dotenv==0.12.0


### PR DESCRIPTION
## 関連Issue
#48 , #49 

## 修正内容
brotli と pygame を requirements.txtに追加しました。