### PR TITLE
トースト通知ウィンドウのデザイン修正

### DIFF
--- a/css/toast_button.css
+++ b/css/toast_button.css
@@ -1,12 +1,8 @@
 QPushButton {
-    border-color: rgba(255, 100, 100, 0);
-    border-style: solid;
-    border-width: 1px;
+    border: 1px solid transparent;
 }
 
 QPushButton:hover {
-    border-color: rgb(255, 100, 100);
-    border-style: solid;
-    border-width: 1px;
+    background: rgb(255, 212, 212);
 }
 

--- a/css/toast_hover.css
+++ b/css/toast_hover.css
@@ -3,34 +3,13 @@ QListWidgetがもともと持っている背景色を透明化し
 トーストウィンドウの背景色に合わせる。
 */
 QListWidget {
-    background-color: transparent;
+    background: transparent;
 }
 
-/*
-マウスホバー時にQListWidgetItem内のオブジェクトが動かないよう
-最初から透明なボーダーを描画しておく。
-*/
 QListWidget::item {
-    background: rgba(255, 212, 212, 0);
-    selection-color: rgb(0, 0 ,0);
-    border:1px solid rgba(255, 100, 100, 0);
-}
-
-/*
-クリックして選択状態になったとき、文字が白色になってしまうので
-黒色のままにする。
-*/
-QListWidget::item:selected {
-    selection-color: rgb(0, 0 ,0);
-    border: 1px solid rgba(255, 100, 100, 0);
+    background: transparent;
 }
 
 QListWidget::item:hover {
     background: rgb(255, 212, 212);
-    selection-color: rgb(0, 0 ,0);
-    border:1px solid rgb(255, 100, 100);
 }
-QListWidget::item:selected:hover {
-    selection-color: rgb(0, 0 ,0);
-}
-

--- a/css/toast_normal.css
+++ b/css/toast_normal.css
@@ -3,26 +3,11 @@ QListWidgetがもともと持っている背景色を透明化し
 トーストウィンドウの背景色に合わせる。
 */
 QListWidget {
-    background-color: transparent;
+    background: transparent;
 }
 
-/*
-マウスホバー有効時と同じレイアウトにするため
-透明なボーダーを描画する。
-*/
 QListWidget::item {
-    background: rgba(255, 212, 212, 0);
-    selection-color: rgb(0, 0 ,0);
-    border:1px solid rgba(255, 100, 100, 0);
-}
-
-/*
-クリックして選択状態になったとき、文字が白色になると見づらいので
-黒色のままにする。
-*/
-QListWidget::item:selected {
-    selection-color: rgb(0, 0 ,0);
-    border: 1px solid rgba(255, 100, 100, 0);
+    background: transparent;
 }
 
 

--- a/toast.py
+++ b/toast.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import (
     QDesktopWidget, QMainWindow, QLabel, QFrame,
     QPushButton, QListWidget, QListWidgetItem)
 from PyQt5.QtGui import QFont, QPixmap, QIcon
-from PyQt5.QtCore import QRect, Qt, QSize, QThread, QObject, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import Qt, QSize, QThread, QObject, pyqtSignal, pyqtSlot
 from functools import partial
 from socket import timeout
 from urllib.request import urlopen, HTTPError, URLError
@@ -40,9 +40,9 @@ class LazyLoader(QObject):
 
 class VideoItem(QListWidgetItem):
 
-    def __init__(self, video):
+    def __init__(self, video, item_height):
         super(VideoItem, self).__init__()
-        self.setSizeHint(QSize(160, 80))
+        self.setSizeHint(QSize(160, item_height))
         self.vid = video["vid"]
         # 動画タイトルを先に設定する。
         self.setFont(QFont("Yu Gothic", 9))
@@ -110,8 +110,12 @@ class Toast(QMainWindow):
         self.initUI(parent)
 
     def initUI(self, parent):
+        padding = 16
+        item_height = 80
+        title_height = 40
+        list_height = min(len(self.videos), 3) * item_height
         width = 450
-        height = 140
+        height = title_height + list_height + padding
         desktop = QDesktopWidget().availableGeometry()
         d_bottom = desktop.bottom()
         d_right = desktop.right()
@@ -120,26 +124,26 @@ class Toast(QMainWindow):
         # Notification text of starting live.
         lblNotice = QLabel(self)
         lblNotice.setFont(QFont("Yu Gothic", 12))
-        lblNotice.setGeometry(QRect(20, 10, width-25, 20))
+        lblNotice.setGeometry(padding, 11, width-title_height, 20)
         lblNotice.setText(parent.localized_text("started"))
         # Close Button
         btnClose = CloseButton(self)
         btnClose.setFlat(True)
         btnClose.clicked.connect(self.close)
         btnClose.setIcon(QIcon(QPixmap("./img/close_button.png")))
-        btnClose.setIconSize(QSize(20, 20))
-        btnClose.setGeometry(width-32, 4, 30, 30)
+        btnClose.setIconSize(QSize(18, 18))
+        btnClose.setGeometry(width-title_height, 0, title_height, title_height)
         # ListBox
         listView = VideoItemList(self, self.already_open_browser)
-        listView.setGeometry(20, 40, width-55, 80)
+        listView.setGeometry(padding, title_height, width-padding*2, list_height)
         listView.itemClicked.connect(self.onItemClicked)
 
         for video in self.videos:
             # 動画情報アイテム
-            item = VideoItem(video)
+            item = VideoItem(video, item_height)
             listView.addItem(item)
             if not self.already_open_browser:
-                listView.setToolTip('Click to open.')
+                listView.setToolTip('Click to open')
         self.show()
 
     def onItemClicked(self, item: QListWidgetItem):


### PR DESCRIPTION
+ ライブ動画を複数検知した時、3つまでは高さを変えて縦に並べるように表示。
3つ以上の場合はスクロールバー表示

+ アイテムやクローズボタンホバー時のグラフィックをよりフラットに。

（Yunzheさんの提案に基づきます。一部ボタンの大きさや位置を変更しました）

イメージ図
1個のとき（＆クローズボタンにマウスホバー状態）
![12](https://user-images.githubusercontent.com/55448286/81287967-aa9efc80-909e-11ea-975f-922211dbd154.PNG)


4個のとき（＆２つ目のアイテムにマウスホバー状態）
![14](https://user-images.githubusercontent.com/55448286/81287900-8ba06a80-909e-11ea-9f74-51f6d8c24c55.PNG)


