### PR TITLE
Fix saving logfiles

### DIFF
--- a/log/test.txt
+++ b/log/test.txt
@@ -1,1 +1,0 @@
-This is test file.

--- a/log_viewer.py
+++ b/log_viewer.py
@@ -20,8 +20,6 @@ class LogViewer(QMainWindow):
 
         with open(logger.get_logfile_path(), encoding="UTF-8") as file:
             log_output.insertPlainText(file.read())
-        with open(logger.get_logfile_path() + ".1", encoding="UTF-8") as file:
-            log_output.insertPlainText(file.read())
 
         font = log_output.font()
         font.setFamily("Yu Gothic")

--- a/logger.py
+++ b/logger.py
@@ -3,16 +3,53 @@ import logging.handlers
 import os
 import settings
 from datetime import datetime
+from glob import glob
 from pathlib import Path
 
-def get_logfile_path():
+
+# ログファイル名。起動時に、日時をベースとしたファイル名を設定。
+log_name = ''.join(['log', datetime.now().strftime("%Y%m%d_%H%M%S"), ".txt"])
+
+
+def remove_old_log(max_logfile_count=5):
+    '''
+    起動時にログフォルダ内に残っているログファイルを走査、
+    「max_logfile_count」個以下のファイル数になるように、古いログファイルを削除する
+
+    parameter
+    ---------
+    max_logfile_count : 残すログファイルの個数
+    '''
+    if max_logfile_count < 1:
+        max_logfile_count = 1
+    # ログフォルダ内のログファイル名の走査、ログファイルのファイル名は昇順ソートしておく
+    baselogdir = os.path.dirname(get_logfile_path())
+    logfilelist = sorted(glob(''.join([baselogdir, '/*', '.txt'])))
+    current_count = len(logfilelist)
+    if current_count < max_logfile_count + 1:
+        return
+    remove_count = current_count - max_logfile_count  # 削除する回数
+    for filename in logfilelist:
+        try:
+            os.remove(filename)
+        except Exception:
+            pass
+        remove_count -= 1
+        if remove_count < 1:
+            break
+
+
+def get_logfile_path() -> str:
+    '''
+    ログファイルのフルパスを返す
+    '''
     parent_dir = os.path.join(".", settings.LOG_DIR)
     Path(parent_dir).mkdir(parents=True, exist_ok=True)
-    logfile_path = os.path.join(parent_dir, settings.LOG_NAME)
+    logfile_path = os.path.join(parent_dir, log_name)
     return logfile_path
 
 
-def get_logger(modname,loglevel=logging.DEBUG):
+def get_logger(modname, loglevel=logging.DEBUG):
     logger = logging.getLogger(modname)
     if loglevel is None:
         logger.addHandler(logging.NullHandler())
@@ -20,14 +57,12 @@ def get_logger(modname,loglevel=logging.DEBUG):
     logger.setLevel(loglevel)
     # create a handler for showing info
     str_handler = logging.StreamHandler()
-    formatter  = LogFormatter()
+    formatter = LogFormatter()
     str_handler.setFormatter(formatter)
     str_handler.setLevel(loglevel) 
     logger.addHandler(str_handler)
     # create a handler for recording log file
-    file_handler = logging.handlers.RotatingFileHandler(
-        filename=get_logfile_path(),
-        encoding='utf-8', maxBytes=100000, backupCount=2)
+    file_handler = logging.FileHandler(filename=get_logfile_path(), encoding='utf-8')
     file_handler.setLevel(loglevel)
     file_handler.setFormatter(LogFormatter())
     logger.addHandler(file_handler)
@@ -44,6 +79,6 @@ class LogFormatter(logging.Formatter):
         lineno = str(record.lineno).rjust(4)
         level = (record.levelname).ljust(6)
         message = record.getMessage()
-        
+
         return '{} - {} - {} :{} - {} -  {}'.format(
             timestamp, filename, module, lineno, level, message)

--- a/mikochiku_alarm.py
+++ b/mikochiku_alarm.py
@@ -46,6 +46,8 @@ class MikochikuAlarm(QWidget):
         self.initUI()
         # 起動直後にチャンネルIDを調べる
         self.check_live()
+        # 古いログファイルを削除しログファイルの数を一定個数以下にする。（既定値：5個）
+        logger.remove_old_log()
 
     def initUI(self):
 
@@ -132,7 +134,7 @@ class MikochikuAlarm(QWidget):
             self.old_video_id_list.append(getting_video_id)
             if len(self.old_video_id_list) > 30:
                 self.old_video_id_list.pop(0)
-            log.info(self.localized_text("started"))
+            log.info(''.join([self.localized_text("started"), ' -[', getting_video_id, '] ', buff_video_id_set[getting_video_id]]))
             log.debug(f"buff_video_id_set: {[id for id in buff_video_id_set.keys()]}")
             log.debug(f"self.old_video_id_list {self.old_video_id_list}")
             self.alarm_stop.click()


### PR DESCRIPTION
## 関連issue
#59 
（ログファイルのファイルサイズが100キロバイトを超えるとログが記録されない）

## 内容
+ ログファイルを起動ごとに作成する。
+ ログファイル名を日時ベースにする。
+ ログファイルの最大個数既定値は直近の5個（ログファイル個数はremove_old_log()の引数で変更可能）

